### PR TITLE
Building 1st level leaves stubs + Acknowledgment/References section implemented

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.idea/inspectionProfiles/
+/.idea/

--- a/cvrf2csaf/cvrf2csaf.py
+++ b/cvrf2csaf/cvrf2csaf.py
@@ -9,6 +9,9 @@ from .common.utils import get_config_from_file, store_json, critical_exit
 
 from .section_handlers.document_tracking import DocumentTracking
 from .section_handlers.document_publisher import DocumentPublisher
+from .section_handlers.document_references import DocumentReferences
+from .section_handlers.acknowlegments import Acknowledgments
+from .section_handlers.product_tree import ProductTree
 
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(module)s - %(levelname)s - %(message)s')
@@ -33,18 +36,38 @@ class DocumentHandler:
         self.document_tracking = DocumentTracking(config['cvrf2csaf_name'],
                                                   config['cvrf2csaf_version'],
                                                   config['force_update_revision_history'])
+        self.document_references = DocumentReferences()
+        self.acknowledgments = Acknowledgments()
+        self.product_tree = ProductTree()
 
     def _parse(self, root):
         for elem in root.iterchildren():
             # get tag name without it's namespace, don't use elem.tag here
             tag = etree.QName(elem).localname
             if tag == 'DocumentPublisher':
-                self.document_publisher.create_csaf(elem)
+                self.document_publisher.create_csaf(root_element=elem)
             elif tag == 'DocumentTracking':
-                self.document_tracking.create_csaf(elem)
-            elif tag == 'ToDo':
-                # ToDo: Going through it tag by tag for further parsing
-                pass
+                self.document_tracking.create_csaf(root_element=elem)
+            elif tag == 'Acknowledgments':
+                self.acknowledgments.create_csaf(root_element=elem)
+            elif tag == 'DocumentNotes':
+                logging.warning(f'Not handled input tag {tag}. No parser available.')
+            elif tag == 'ProductTree':
+                self.product_tree.create_csaf(root_element=elem)
+                logging.warning(f'Not implemented input tag {tag}. No parser available.')
+            elif tag == 'DocumentTitle':
+                logging.warning(f'Not handled input tag {tag}. No parser available.')
+            elif tag == 'DocumentType':
+                logging.warning(f'Not handled input tag {tag}. No parser available.')
+            elif tag == 'DocumentDistribution':
+                logging.warning(f'Not handled input tag {tag}. No parser available.')
+            elif tag == 'DocumentDistribution':
+                logging.warning(f'Not handled input tag {tag}. No parser available.')
+            elif tag == 'DocumentReferences':
+                self.document_references.create_csaf(root_element=elem)
+                logging.warning(f'Not implemented input tag {tag}. No parser available.')
+            elif tag in ['comment']:
+                logging.warning(f'Not handled input tag {tag}. No parser available.')
             else:
                 logging.warning(f'Not handled input tag {tag}. No parser available.')
 
@@ -52,6 +75,9 @@ class DocumentHandler:
         final_csaf = {'document': {}}
         final_csaf['document']['publisher'] = self.document_publisher.csaf
         final_csaf['document']['tracking'] = self.document_tracking.csaf
+        final_csaf['document']['references'] = self.document_references.csaf
+        final_csaf['document']['acknowledgments'] = self.acknowledgments.csaf
+        final_csaf['document']['product_tree'] = self.product_tree.csaf
         return final_csaf
 
     @classmethod

--- a/cvrf2csaf/cvrf2csaf.py
+++ b/cvrf2csaf/cvrf2csaf.py
@@ -115,7 +115,8 @@ class DocumentHandler:
         final_csaf['product_tree'] = self.product_tree.csaf
         final_csaf['document']['tracking'] = self.document_tracking.csaf
         final_csaf['document']['references'] = self.document_references.csaf
-        final_csaf['document']['vulnerability'] = self.vulnerability.csaf
+        final_csaf['product_tree'] = self.product_tree.csaf
+        final_csaf['vulnerabilities'] = self.vulnerability.csaf
 
         return final_csaf
 

--- a/cvrf2csaf/cvrf2csaf.py
+++ b/cvrf2csaf/cvrf2csaf.py
@@ -10,7 +10,6 @@ from .common.utils import get_config_from_file, store_json, critical_exit
 from .section_handlers.document_acknowlegments import Acknowledgments
 from .section_handlers.document_aggregate_severity import AggregateSeverity
 from .section_handlers.document_category import DocumentCategory
-from .section_handlers.comment import Comment
 from .section_handlers.document_csaf_version import DocumentCsafVersion
 from .section_handlers.document_distribution import DocumentDistribution
 from .section_handlers.document_lang import DocumentLang
@@ -45,7 +44,6 @@ class DocumentHandler:
 
         self.document_acknowledgments = Acknowledgments()
         self.document_aggregate_severity = AggregateSeverity()
-        self.comment = Comment()
         self.document_category = DocumentCategory()
         self.document_csaf_version = DocumentCsafVersion()
         self.document_distribution = DocumentDistribution()
@@ -94,7 +92,7 @@ class DocumentHandler:
             elif tag == 'Vulnerability':
                 self.vulnerability.create_csaf(root_element=elem)
             elif tag in ['comment']:
-                self.comment.create_csaf(root_element=elem)
+                logging.warning(f'Ignoring invalid input tag {tag}.')
             else:
                 logging.warning(f'Not handled input tag {tag}. No parser available.')
 

--- a/cvrf2csaf/cvrf2csaf.py
+++ b/cvrf2csaf/cvrf2csaf.py
@@ -61,8 +61,6 @@ class DocumentHandler:
                 logging.warning(f'Not handled input tag {tag}. No parser available.')
             elif tag == 'DocumentDistribution':
                 logging.warning(f'Not handled input tag {tag}. No parser available.')
-            elif tag == 'DocumentDistribution':
-                logging.warning(f'Not handled input tag {tag}. No parser available.')
             elif tag == 'DocumentReferences':
                 self.document_references.create_csaf(root_element=elem)
                 logging.warning(f'Not implemented input tag {tag}. No parser available.')

--- a/cvrf2csaf/cvrf2csaf.py
+++ b/cvrf2csaf/cvrf2csaf.py
@@ -112,11 +112,9 @@ class DocumentHandler:
         final_csaf['document']['references'] = self.document_references.csaf
         final_csaf['document']['title'] = self.document_title.csaf
         final_csaf['document']['tracking'] = self.document_tracking.csaf
-        final_csaf['document']['product_tree'] = self.product_tree.csaf
-
+        final_csaf['product_tree'] = self.product_tree.csaf
         final_csaf['document']['tracking'] = self.document_tracking.csaf
         final_csaf['document']['references'] = self.document_references.csaf
-        final_csaf['document']['product_tree'] = self.product_tree.csaf
         final_csaf['document']['vulnerability'] = self.vulnerability.csaf
 
         return final_csaf

--- a/cvrf2csaf/cvrf2csaf.py
+++ b/cvrf2csaf/cvrf2csaf.py
@@ -112,7 +112,6 @@ class DocumentHandler:
         final_csaf['document']['references'] = self.document_references.csaf
         final_csaf['document']['title'] = self.document_title.csaf
         final_csaf['document']['tracking'] = self.document_tracking.csaf
-        final_csaf['product_tree'] = self.product_tree.csaf
         final_csaf['document']['tracking'] = self.document_tracking.csaf
         final_csaf['document']['references'] = self.document_references.csaf
         final_csaf['product_tree'] = self.product_tree.csaf

--- a/cvrf2csaf/cvrf2csaf.py
+++ b/cvrf2csaf/cvrf2csaf.py
@@ -7,11 +7,22 @@ from lxml import objectify
 
 from .common.utils import get_config_from_file, store_json, critical_exit
 
-from .section_handlers.document_tracking import DocumentTracking
+from .section_handlers.document_acknowlegments import Acknowledgments
+from .section_handlers.document_aggregate_severity import AggregateSeverity
+from .section_handlers.document_category import DocumentCategory
+from .section_handlers.comment import Comment
+from .section_handlers.document_csaf_version import DocumentCsafVersion
+from .section_handlers.document_distribution import DocumentDistribution
+from .section_handlers.document_lang import DocumentLang
+from .section_handlers.document_notes import DocumentNotes
 from .section_handlers.document_publisher import DocumentPublisher
 from .section_handlers.document_references import DocumentReferences
-from .section_handlers.acknowlegments import Acknowledgments
+from .section_handlers.document_source_lang import DocumentSourceLang
+from .section_handlers.document_title import DocumentTitle
+from .section_handlers.document_tracking import DocumentTracking
+
 from .section_handlers.product_tree import ProductTree
+from .section_handlers.vulnerability import Vulnerability
 
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(module)s - %(levelname)s - %(message)s')
@@ -31,51 +42,85 @@ class DocumentHandler:
     CATALOG_FILE = 'schemata/catalog_1_2.xml'
 
     def __init__(self, config):
+
+        self.document_acknowledgments = Acknowledgments()
+        self.document_aggregate_severity = AggregateSeverity()
+        self.comment = Comment()
+        self.document_category = DocumentCategory()
+        self.document_csaf_version = DocumentCsafVersion()
+        self.document_distribution = DocumentDistribution()
+        self.document_lang = DocumentLang()
+        self.document_notes = DocumentNotes()
         self.document_publisher = DocumentPublisher(config['publisher_name'],
                                                     config['publisher_namespace'])
+        self.document_references = DocumentReferences()
+        self.document_source_lang = DocumentSourceLang()
+        self.document_title = DocumentTitle()
         self.document_tracking = DocumentTracking(config['cvrf2csaf_name'],
                                                   config['cvrf2csaf_version'],
                                                   config['force_update_revision_history'])
-        self.document_references = DocumentReferences()
-        self.acknowledgments = Acknowledgments()
         self.product_tree = ProductTree()
+        self.vulnerability = Vulnerability()
+
 
     def _parse(self, root):
         for elem in root.iterchildren():
             # get tag name without it's namespace, don't use elem.tag here
             tag = etree.QName(elem).localname
-            if tag == 'DocumentPublisher':
-                self.document_publisher.create_csaf(root_element=elem)
-            elif tag == 'DocumentTracking':
-                self.document_tracking.create_csaf(root_element=elem)
-            elif tag == 'Acknowledgments':
-                self.acknowledgments.create_csaf(root_element=elem)
-            elif tag == 'DocumentNotes':
-                logging.warning(f'Not handled input tag {tag}. No parser available.')
-            elif tag == 'ProductTree':
-                self.product_tree.create_csaf(root_element=elem)
-                logging.warning(f'Not implemented input tag {tag}. No parser available.')
-            elif tag == 'DocumentTitle':
-                logging.warning(f'Not handled input tag {tag}. No parser available.')
+
+            # ToDo: Lang and SourceLang are missing here.
+
+            if tag == 'Acknowledgments':
+                self.document_acknowledgments.create_csaf(root_element=elem)
+            elif tag == 'AggregateSeverity':
+                self.document_aggregate_severity.create_csaf(root_element=elem)
             elif tag == 'DocumentType':
-                logging.warning(f'Not handled input tag {tag}. No parser available.')
+                # Map DocumentType --> /document/category/
+                self.document_category.create_csaf(root_element=elem)
             elif tag == 'DocumentDistribution':
-                logging.warning(f'Not handled input tag {tag}. No parser available.')
+                self.document_distribution.create_csaf(root_element=elem)
+            elif tag == 'DocumentNotes':
+                self.document_notes.create_csaf(root_element=elem)
+            elif tag == 'DocumentPublisher':
+                self.document_publisher.create_csaf(root_element=elem)
             elif tag == 'DocumentReferences':
                 self.document_references.create_csaf(root_element=elem)
-                logging.warning(f'Not implemented input tag {tag}. No parser available.')
+            elif tag == 'DocumentTitle':
+                self.document_title.create_csaf(root_element=elem)
+            elif tag == 'DocumentTracking':
+                self.document_tracking.create_csaf(root_element=elem)
+            elif tag == 'ProductTree':
+                self.product_tree.create_csaf(root_element=elem)
+            elif tag == 'Vulnerability':
+                self.vulnerability.create_csaf(root_element=elem)
             elif tag in ['comment']:
-                logging.warning(f'Not handled input tag {tag}. No parser available.')
+                self.comment.create_csaf(root_element=elem)
             else:
                 logging.warning(f'Not handled input tag {tag}. No parser available.')
 
     def _compose_final_csaf(self) -> dict:
+        # Merges first level leaves into final CSAF document.
+        # [mapping table](https://github.com/tschmidtb51/csaf/blob/csaf-2.0-what-is-new-table/notes/whats-new-csaf-v2.0-cn01.md#e4-mapped-elements)
+
         final_csaf = {'document': {}}
+        final_csaf['document']['acknowledgments'] = self.document_acknowledgments.csaf
+        final_csaf['document']['aggregate_severity'] = self.document_aggregate_severity.csaf
+        final_csaf['document']['category'] = self.document_category.csaf
+        final_csaf['document']['distribution'] = self.document_distribution.csaf
+        final_csaf['document']['lang'] = self.document_lang.csaf
+        final_csaf['document']['notes'] = self.document_notes.csaf
         final_csaf['document']['publisher'] = self.document_publisher.csaf
+        final_csaf['document']['source_lang'] = self.document_source_lang.csaf
+        final_csaf['document']['references'] = self.document_references.csaf
+        final_csaf['document']['title'] = self.document_title.csaf
+        final_csaf['document']['tracking'] = self.document_tracking.csaf
+        final_csaf['document']['product_tree'] = self.product_tree.csaf
+
         final_csaf['document']['tracking'] = self.document_tracking.csaf
         final_csaf['document']['references'] = self.document_references.csaf
-        final_csaf['document']['acknowledgments'] = self.acknowledgments.csaf
         final_csaf['document']['product_tree'] = self.product_tree.csaf
+        final_csaf['document']['vulnerability'] = self.vulnerability.csaf
+
         return final_csaf
 
     @classmethod

--- a/cvrf2csaf/section_handlers/acknowlegments.py
+++ b/cvrf2csaf/section_handlers/acknowlegments.py
@@ -1,0 +1,34 @@
+
+from ..common.common import SectionHandler
+
+
+class Acknowledgments(SectionHandler):
+    def __init__(self):
+        super().__init__()
+
+    def _process_mandatory_elements(self, root_element):
+
+        if hasattr(root_element, 'Acknowledgment'):
+            # at least one entry in list of Acknowledgments
+            pass # No field is mandatory due to CVRF.xsd; version 1.2
+
+
+    def _process_optional_elements(self, root_element):
+        # optional values
+        names = []
+        organization = []
+        summary = []
+        urls = []
+        for ack in root_element.Acknowledgment:
+            names.append(ack.Name.text)
+            if hasattr(ack, 'Organization'):
+                organization.append(ack.Organization.text)
+            if hasattr(ack, 'Summary'):
+                summary.append(ack.Summary.text)
+            if hasattr(ack, 'Url'):
+                urls.append(ack.Url.text)
+
+        self.csaf['names'] = names
+        self.csaf['organization'] = organization
+        self.csaf['summary'] = summary
+        self.csaf['urls'] = urls

--- a/cvrf2csaf/section_handlers/comment.py
+++ b/cvrf2csaf/section_handlers/comment.py
@@ -2,7 +2,7 @@ import logging
 from ..common.common import SectionHandler
 
 
-class ProductTree(SectionHandler):
+class Comment(SectionHandler):
     def __init__(self):
         super().__init__()
 

--- a/cvrf2csaf/section_handlers/document_acknowlegments.py
+++ b/cvrf2csaf/section_handlers/document_acknowlegments.py
@@ -1,4 +1,4 @@
-
+import logging
 from ..common.common import SectionHandler
 
 
@@ -29,6 +29,14 @@ class Acknowledgments(SectionHandler):
                 urls.append(ack.Url.text)
 
         self.csaf['names'] = names
-        self.csaf['organization'] = organization
+
+        if len(organization)>=1:
+            # If more than one cvrf:Organization instance is given,
+            # the CVRF CSAF converter converts the first one into the organization.
+            # In addition the converter outputs a warning that information might be lost during conversion of document or vulnerability acknowledgment.
+            self.csaf['organization'] = organization[0]
+            if len(organization) > 1:
+                logging.warn(f'Due to CSAF 2.0 standard, only the first organization can be acknowledged. '
+                             f'{len(organization)-1} are not mentioned in the output.')
         self.csaf['summary'] = summary
         self.csaf['urls'] = urls

--- a/cvrf2csaf/section_handlers/document_acknowlegments.py
+++ b/cvrf2csaf/section_handlers/document_acknowlegments.py
@@ -28,8 +28,6 @@ class Acknowledgments(SectionHandler):
             if hasattr(ack, 'Url'):
                 urls.append(ack.Url.text)
 
-        self.csaf['names'] = names
-
         if len(organization)>=1:
             # If more than one cvrf:Organization instance is given,
             # the CVRF CSAF converter converts the first one into the organization.
@@ -38,5 +36,9 @@ class Acknowledgments(SectionHandler):
             if len(organization) > 1:
                 logging.warn(f'Due to CSAF 2.0 standard, only the first organization can be acknowledged. '
                              f'{len(organization)-1} are not mentioned in the output.')
-        self.csaf['summary'] = summary
-        self.csaf['urls'] = urls
+        if len(names) > 0:
+            self.csaf['names'] = names
+        if len(summary) > 0:
+            self.csaf['summary'] = summary
+        if len(urls) > 0:
+            self.csaf['urls'] = urls

--- a/cvrf2csaf/section_handlers/document_aggregate_severity.py
+++ b/cvrf2csaf/section_handlers/document_aggregate_severity.py
@@ -2,7 +2,7 @@ import logging
 from ..common.common import SectionHandler
 
 
-class ProductTree(SectionHandler):
+class AggregateSeverity(SectionHandler):
     def __init__(self):
         super().__init__()
 

--- a/cvrf2csaf/section_handlers/document_category.py
+++ b/cvrf2csaf/section_handlers/document_category.py
@@ -7,7 +7,7 @@ class DocumentCategory(SectionHandler):
         super().__init__()
 
     def _process_mandatory_elements(self, root_element):
-        logging.warning(f'Not implemented input {self.__class__}. No parser written.')
+        self.csaf = root_element.text
 
     def _process_optional_elements(self, root_element):
         pass

--- a/cvrf2csaf/section_handlers/document_category.py
+++ b/cvrf2csaf/section_handlers/document_category.py
@@ -2,7 +2,7 @@ import logging
 from ..common.common import SectionHandler
 
 
-class ProductTree(SectionHandler):
+class DocumentCategory(SectionHandler):
     def __init__(self):
         super().__init__()
 

--- a/cvrf2csaf/section_handlers/document_csaf_version.py
+++ b/cvrf2csaf/section_handlers/document_csaf_version.py
@@ -2,7 +2,7 @@ import logging
 from ..common.common import SectionHandler
 
 
-class ProductTree(SectionHandler):
+class DocumentCsafVersion(SectionHandler):
     def __init__(self):
         super().__init__()
 

--- a/cvrf2csaf/section_handlers/document_distribution.py
+++ b/cvrf2csaf/section_handlers/document_distribution.py
@@ -2,7 +2,7 @@ import logging
 from ..common.common import SectionHandler
 
 
-class ProductTree(SectionHandler):
+class DocumentDistribution(SectionHandler):
     def __init__(self):
         super().__init__()
 

--- a/cvrf2csaf/section_handlers/document_lang.py
+++ b/cvrf2csaf/section_handlers/document_lang.py
@@ -2,7 +2,7 @@ import logging
 from ..common.common import SectionHandler
 
 
-class ProductTree(SectionHandler):
+class DocumentLang(SectionHandler):
     def __init__(self):
         super().__init__()
 

--- a/cvrf2csaf/section_handlers/document_notes.py
+++ b/cvrf2csaf/section_handlers/document_notes.py
@@ -2,7 +2,7 @@ import logging
 from ..common.common import SectionHandler
 
 
-class ProductTree(SectionHandler):
+class DocumentNotes(SectionHandler):
     def __init__(self):
         super().__init__()
 

--- a/cvrf2csaf/section_handlers/document_references.py
+++ b/cvrf2csaf/section_handlers/document_references.py
@@ -12,6 +12,8 @@ class DocumentReferences(SectionHandler):
         if hasattr(root_element, 'Reference'):
             for ref in root_element.Reference:
                 ref_csaf = dict()
+                if 'Type' not in ref.attrib or len(ref.attrib['Type']) < 2:
+                    ref_csaf['category'] = 'external'
                 ref_csaf['category'] = str(ref.attrib['Type'])
                 if hasattr(ref, 'Description'):
                     ref_csaf['summary'] = ref.Description.text

--- a/cvrf2csaf/section_handlers/document_references.py
+++ b/cvrf2csaf/section_handlers/document_references.py
@@ -19,7 +19,7 @@ class DocumentReferences(SectionHandler):
                     ref_csaf['url'] = ref.URL.text
                 references.append(ref_csaf)
 
-        self.csaf['references'] = references
+        self.csaf = references
 
     def _process_optional_elements(self, root_element):
         pass

--- a/cvrf2csaf/section_handlers/document_references.py
+++ b/cvrf2csaf/section_handlers/document_references.py
@@ -7,6 +7,19 @@ class DocumentReferences(SectionHandler):
         super().__init__()
 
     def _process_mandatory_elements(self, root_element):
-        pass
+
+        references = []
+        if hasattr(root_element, 'Reference'):
+            for ref in root_element.Reference:
+                ref_csaf = dict()
+                ref_csaf['category'] = str(ref.attrib['Type'])
+                if hasattr(ref, 'Description'):
+                    ref_csaf['summary'] = ref.Description.text
+                if hasattr(ref, 'URL'):
+                    ref_csaf['url'] = ref.URL.text
+                references.append(ref_csaf)
+
+        self.csaf['references'] = references
+
     def _process_optional_elements(self, root_element):
         pass

--- a/cvrf2csaf/section_handlers/document_references.py
+++ b/cvrf2csaf/section_handlers/document_references.py
@@ -1,0 +1,12 @@
+
+from ..common.common import SectionHandler
+
+
+class DocumentReferences(SectionHandler):
+    def __init__(self):
+        super().__init__()
+
+    def _process_mandatory_elements(self, root_element):
+        pass
+    def _process_optional_elements(self, root_element):
+        pass

--- a/cvrf2csaf/section_handlers/document_source_lang.py
+++ b/cvrf2csaf/section_handlers/document_source_lang.py
@@ -2,7 +2,7 @@ import logging
 from ..common.common import SectionHandler
 
 
-class ProductTree(SectionHandler):
+class DocumentSourceLang(SectionHandler):
     def __init__(self):
         super().__init__()
 

--- a/cvrf2csaf/section_handlers/document_title.py
+++ b/cvrf2csaf/section_handlers/document_title.py
@@ -7,7 +7,7 @@ class DocumentTitle(SectionHandler):
         super().__init__()
 
     def _process_mandatory_elements(self, root_element):
-        logging.warning(f'Not implemented input {self.__class__}. No parser written.')
+        self.csaf = root_element.text
 
     def _process_optional_elements(self, root_element):
         pass

--- a/cvrf2csaf/section_handlers/document_title.py
+++ b/cvrf2csaf/section_handlers/document_title.py
@@ -2,7 +2,7 @@ import logging
 from ..common.common import SectionHandler
 
 
-class ProductTree(SectionHandler):
+class DocumentTitle(SectionHandler):
     def __init__(self):
         super().__init__()
 

--- a/cvrf2csaf/section_handlers/product_tree.py
+++ b/cvrf2csaf/section_handlers/product_tree.py
@@ -1,0 +1,13 @@
+
+from ..common.common import SectionHandler
+
+
+class ProductTree(SectionHandler):
+    def __init__(self):
+        super().__init__()
+
+    def _process_mandatory_elements(self, root_element):
+        pass
+
+    def _process_optional_elements(self, root_element):
+        pass

--- a/cvrf2csaf/section_handlers/vulnerability.py
+++ b/cvrf2csaf/section_handlers/vulnerability.py
@@ -2,12 +2,12 @@ import logging
 from ..common.common import SectionHandler
 
 
-class ProductTree(SectionHandler):
+class Vulnerability(SectionHandler):
     def __init__(self):
         super().__init__()
 
     def _process_mandatory_elements(self, root_element):
-        logging.warning(f'Not implemented input {self.__class__}. No parser written.')
+        logging.warning(f'Not implemented input tag {self.__class__}. No parser available.')
 
     def _process_optional_elements(self, root_element):
         pass


### PR DESCRIPTION
- First review of [Mapped elements](https://github.com/tschmidtb51/csaf/blob/csaf-2.0-what-is-new-table/notes/whats-new-csaf-v2.0-cn01.md#e4-mapped-elements)
+ Implementing document_references.py (#28)
+ Implement special case for acknowlegments #29 -> "If more than one cvrf:Organization instance is given, the CVRF CSAF converter converts the first one into the organization."

Remarks:
- Seperating work without touching the main cvrf2csaf.py is easier now.
- First level mapping has been made -> Now getting into more parsers.