### PR TITLE
Implement the whole ProductTree section

### DIFF
--- a/cvrf2csaf/cvrf2csaf.py
+++ b/cvrf2csaf/cvrf2csaf.py
@@ -9,6 +9,7 @@ from .common.utils import get_config_from_file, store_json, critical_exit
 
 from .section_handlers.document_tracking import DocumentTracking
 from .section_handlers.document_publisher import DocumentPublisher
+from .section_handlers.product_tree import ProductTree
 
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(module)s - %(levelname)s - %(message)s')
@@ -34,6 +35,9 @@ class DocumentHandler:
                                                   config['cvrf2csaf_version'],
                                                   config['force_update_revision_history'])
 
+        self.product_tree = ProductTree()
+
+
     def _parse(self, root):
         for elem in root.iterchildren():
             # get tag name without it's namespace, don't use elem.tag here
@@ -42,6 +46,8 @@ class DocumentHandler:
                 self.document_publisher.create_csaf(elem)
             elif tag == 'DocumentTracking':
                 self.document_tracking.create_csaf(elem)
+            elif tag == 'ProductTree':
+                self.product_tree.create_csaf(elem)
             elif tag == 'ToDo':
                 # ToDo: Going through it tag by tag for further parsing
                 pass
@@ -52,6 +58,7 @@ class DocumentHandler:
         final_csaf = {'document': {}}
         final_csaf['document']['publisher'] = self.document_publisher.csaf
         final_csaf['document']['tracking'] = self.document_tracking.csaf
+        final_csaf['document']['product_tree'] = self.product_tree.csaf
         return final_csaf
 
     @classmethod

--- a/cvrf2csaf/section_handlers/product_tree.py
+++ b/cvrf2csaf/section_handlers/product_tree.py
@@ -9,46 +9,79 @@ class ProductTree(SectionHandler):
         """ There are no mandatory elements in the ProductTree section """
         pass
 
+    def _handle_full_product_names(self, root_element):
+        if not hasattr(root_element, 'FullProductName'):
+            return
+
+        full_product_names = []
+        for full_product_name in root_element.FullProductName:
+            fpn_to_add = {
+                'product_id': full_product_name.attrib['ProductID'],
+                'name': full_product_name.text,
+            }
+            if full_product_name.attrib.get('CPE'):
+                fpn_to_add['product_identification_helper'] = {'cpe': full_product_name.attrib['CPE']}
+
+            full_product_names.append(fpn_to_add)
+
+        self.csaf['full_product_names'] = full_product_names
+
+    def _handle_relationships(self, root_element):
+        if not hasattr(root_element, 'Relationship'):
+            return
+
+        relationships = []
+        for relationship in root_element.Relationship:
+            first_prod_name = relationship.FullProductName[0]
+
+            if len(relationship.FullProductName) > 1:
+                # To be compliant with 9.1.5 Conformance Clause 5: CVRF CSAF converter
+                # https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html
+                logging.warning(f'Input line {relationship.sourceline}: Relationship contains more '
+                                'FullProductNames. Taking only the first one, since CSAF expects '
+                                'only 1 value here')
+
+            rel_to_add = {
+                'category': relationship.attrib['RelationType'],
+                'product_reference': relationship.attrib['ProductReference'],
+                'relates_to_product_reference': relationship.attrib['RelatesToProductReference'],
+                'full_product_name': {
+                    'product_id': first_prod_name.attrib['ProductID'],
+                    'name': first_prod_name.text,
+                }
+            }
+
+            if first_prod_name.attrib.get('CPE'):
+                rel_to_add['full_product_name']['product_identification_helper'] = {'cpe': first_prod_name.attrib['CPE']}
+
+            relationships.append(rel_to_add)
+
+        self.csaf['relationships'] = relationships
+
+
+    def _handle_product_groups(self, root_element):
+        if not hasattr(root_element, 'ProductGroups'):
+            return
+
+        product_groups = []
+        for product_group in root_element.ProductGroups.Group:
+            product_ids = [x.text for x in product_group.ProductID]
+            pg_to_add = {
+                'group_id': product_group.attrib['GroupID'],
+                'product_ids': product_ids,
+            }
+
+            if hasattr(product_group, 'Description'):
+                pg_to_add['summary'] = product_group.Description.text
+
+            product_groups.append(pg_to_add)
+
+        self.csaf['product_groups'] = product_groups
+
+    def _handle_branches(self, root_element):
+        pass
+
     def _process_optional_elements(self, root_element):
-        if hasattr(root_element, 'FullProductName'):
-            full_product_names = []
-            for full_product_name in root_element.FullProductName:
-                fpn_to_add = {
-                    'product_id': full_product_name.attrib['ProductID'],
-                    'name': full_product_name.text,
-                }
-                if full_product_name.attrib.get('CPE'):
-                    fpn_to_add['product_identification_helper'] = {'cpe': full_product_name.attrib['CPE']}
-
-                full_product_names.append(fpn_to_add)
-
-            self.csaf['full_product_names'] = full_product_names
-
-        if hasattr(root_element, 'Relationship'):
-            relationships = []
-            for relationship in root_element.Relationship:
-                first_prod_name = relationship.FullProductName[0]
-
-                if len(relationship.FullProductName) > 1:
-                    # To be compliant with 9.1.5 Conformance Clause 5: CVRF CSAF converter
-                    # https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html
-                    logging.warning(f'Input line {relationship.sourceline}: Relationship contains more '
-                                    'FullProductNames. Taking only the first one, since CSAF expects '
-                                    'only 1 value here')
-
-                rel_to_add = {
-                    'category': relationship.attrib['RelationType'],
-                    'product_reference': relationship.attrib['ProductReference'],
-                    'relates_to_product_reference': relationship.attrib['RelatesToProductReference'],
-                    'full_product_name': {
-                        'product_id': first_prod_name.attrib['ProductID'],
-                        'name': first_prod_name.text,
-                    }
-                }
-
-                if first_prod_name.attrib.get('CPE'):
-                    rel_to_add['full_product_name']['product_identification_helper'] = {'cpe': first_prod_name.attrib['CPE']}
-
-                relationships.append(rel_to_add)
-
-                self.csaf['relationships'] = relationships
+        self._handle_full_product_names(root_element)
+        self._handle_relationships(root_element)
+        self._handle_product_groups(root_element)

--- a/cvrf2csaf/section_handlers/product_tree.py
+++ b/cvrf2csaf/section_handlers/product_tree.py
@@ -5,6 +5,9 @@ from ..common.common import SectionHandler
 class ProductTree(SectionHandler):
     """ Responsible for converting the ProductTree section """
 
+    def __init__(self):
+        super().__init__()
+
     def _process_mandatory_elements(self, root_element):
         """ There are no mandatory elements in the ProductTree section """
         pass
@@ -67,7 +70,6 @@ class ProductTree(SectionHandler):
 
         self.csaf['relationships'] = relationships
 
-
     def _handle_product_groups(self, root_element):
         if not hasattr(root_element, 'ProductGroups'):
             return
@@ -92,6 +94,7 @@ class ProductTree(SectionHandler):
         or a single FullProductName inside
         """
         if not hasattr(root_element, 'Branch') and not hasattr(root_element, 'FullProductName'):
+            # The ProductTree section doesn't contain Branches at all
             return None
 
         if hasattr(root_element, 'FullProductName'):
@@ -124,6 +127,3 @@ class ProductTree(SectionHandler):
                     })
 
             return branches
-
-
-

--- a/cvrf2csaf/section_handlers/product_tree.py
+++ b/cvrf2csaf/section_handlers/product_tree.py
@@ -9,6 +9,15 @@ class ProductTree(SectionHandler):
         """ There are no mandatory elements in the ProductTree section """
         pass
 
+    def _process_optional_elements(self, root_element):
+        self._handle_full_product_names(root_element)
+        self._handle_relationships(root_element)
+        self._handle_product_groups(root_element)
+
+        branches = self._handle_branches_recursive(root_element)
+        if branches is not None:
+            self.csaf['branches'] = branches
+
     def _handle_full_product_names(self, root_element):
         if not hasattr(root_element, 'FullProductName'):
             return
@@ -97,8 +106,8 @@ class ProductTree(SectionHandler):
                 }
             }
 
-            if root_element.attrib.get('CPE'):
-                leaf_branch['product']['product_identification_helper'] = {'cpe': root_element.attrib['CPE']}
+            if root_element.FullProductName.attrib.get('CPE'):
+                leaf_branch['product']['product_identification_helper'] = {'cpe': root_element.FullProductName.attrib['CPE']}
 
             return leaf_branch
 
@@ -117,11 +126,4 @@ class ProductTree(SectionHandler):
             return branches
 
 
-    def _process_optional_elements(self, root_element):
-        self._handle_full_product_names(root_element)
-        self._handle_relationships(root_element)
-        self._handle_product_groups(root_element)
 
-        branches = self._handle_branches_recursive(root_element)
-        if branches is not None:
-            self.csaf['branches'] = branches

--- a/cvrf2csaf/section_handlers/product_tree.py
+++ b/cvrf2csaf/section_handlers/product_tree.py
@@ -1,11 +1,5 @@
 import logging
-import re
-import sys
-from operator import itemgetter
-from typing import Tuple
 from ..common.common import SectionHandler
-from ..common.utils import get_utc_timestamp
-
 
 
 class ProductTree(SectionHandler):
@@ -19,21 +13,42 @@ class ProductTree(SectionHandler):
         if hasattr(root_element, 'FullProductName'):
             full_product_names = []
             for full_product_name in root_element.FullProductName:
-                full_product_names.append({
+                fpn_to_add = {
                     'product_id': full_product_name.attrib['ProductID'],
                     'name': full_product_name.text,
-                    'product_identification_helper': {'cpe': full_product_name.attrib['CPE']},
-                })
+                }
+                if full_product_name.attrib.get('CPE'):
+                    fpn_to_add['product_identification_helper'] = {'cpe': full_product_name.attrib['CPE']}
+
+                full_product_names.append(fpn_to_add)
 
             self.csaf['full_product_names'] = full_product_names
 
-        # if hasattr(root_element, 'Relationship'):
-        #     relationships = []
-        #     for relationship in root_element.Relationship:
-        #         relationships.append({
-        #             # optional CPE attribute in CVRF is omitted (not present in CSAF specification)
-        #             # 'product_id': full_product_name.attrib['ProductID'],
-        #             # 'name': full_product_name.text,
-        #         })
-        #
-        #     self.csaf['relationships'] = relationships
+        if hasattr(root_element, 'Relationship'):
+            relationships = []
+            for relationship in root_element.Relationship:
+                first_prod_name = relationship.FullProductName[0]
+
+                if len(relationship.FullProductName) > 1:
+                    # To be compliant with 9.1.5 Conformance Clause 5: CVRF CSAF converter
+                    # https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html
+                    logging.warning(f'Input line {relationship.sourceline}: Relationship contains more '
+                                    'FullProductNames. Taking only the first one, since CSAF expects '
+                                    'only 1 value here')
+
+                rel_to_add = {
+                    'category': relationship.attrib['RelationType'],
+                    'product_reference': relationship.attrib['ProductReference'],
+                    'relates_to_product_reference': relationship.attrib['RelatesToProductReference'],
+                    'full_product_name': {
+                        'product_id': first_prod_name.attrib['ProductID'],
+                        'name': first_prod_name.text,
+                    }
+                }
+
+                if first_prod_name.attrib.get('CPE'):
+                    rel_to_add['full_product_name']['product_identification_helper'] = {'cpe': first_prod_name.attrib['CPE']}
+
+                relationships.append(rel_to_add)
+
+                self.csaf['relationships'] = relationships

--- a/cvrf2csaf/section_handlers/product_tree.py
+++ b/cvrf2csaf/section_handlers/product_tree.py
@@ -38,8 +38,8 @@ class ProductTree(SectionHandler):
             return
 
         full_product_names = []
-        for full_product_name in root_element.FullProductName:
-            full_product_names.append(self._construct_full_product_name(full_product_name))
+        for fpn_elem in root_element.FullProductName:
+            full_product_names.append(self._construct_full_product_name(fpn_elem))
 
         self.csaf['full_product_names'] = full_product_names
 
@@ -48,20 +48,20 @@ class ProductTree(SectionHandler):
             return
 
         relationships = []
-        for relationship in root_element.Relationship:
-            first_prod_name = relationship.FullProductName[0]
+        for rel_elem in root_element.Relationship:
+            first_prod_name = rel_elem.FullProductName[0]
 
-            if len(relationship.FullProductName) > 1:
+            if len(rel_elem.FullProductName) > 1:
                 # To be compliant with 9.1.5 Conformance Clause 5: CVRF CSAF converter
                 # https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html
-                logging.warning(f'Input line {relationship.sourceline}: Relationship contains more '
+                logging.warning(f'Input line {rel_elem.sourceline}: Relationship contains more '
                                 'FullProductNames. Taking only the first one, since CSAF expects '
                                 'only 1 value here')
 
             rel_to_add = {
-                'category': relationship.attrib['RelationType'],
-                'product_reference': relationship.attrib['ProductReference'],
-                'relates_to_product_reference': relationship.attrib['RelatesToProductReference'],
+                'category': rel_elem.attrib['RelationType'],
+                'product_reference': rel_elem.attrib['ProductReference'],
+                'relates_to_product_reference': rel_elem.attrib['RelatesToProductReference'],
                 'full_product_name': self._construct_full_product_name(first_prod_name)
             }
 
@@ -74,15 +74,15 @@ class ProductTree(SectionHandler):
             return
 
         product_groups = []
-        for product_group in root_element.ProductGroups.Group:
-            product_ids = [x.text for x in product_group.ProductID]
+        for pg_elem in root_element.ProductGroups.Group:
+            product_ids = [x.text for x in pg_elem.ProductID]
             pg_to_add = {
-                'group_id': product_group.attrib['GroupID'],
+                'group_id': pg_elem.attrib['GroupID'],
                 'product_ids': product_ids,
             }
 
-            if hasattr(product_group, 'Description'):
-                pg_to_add['summary'] = product_group.Description.text
+            if hasattr(pg_elem, 'Description'):
+                pg_to_add['summary'] = pg_elem.Description.text
 
             product_groups.append(pg_to_add)
 
@@ -109,14 +109,14 @@ class ProductTree(SectionHandler):
 
         if hasattr(root_element, 'Branch'):
             branches = []
-            for branch in root_element.Branch:
-                if hasattr(branch, 'FullProductName'):
-                    branches.append(self._handle_branches_recursive(branch))
+            for branch_elem in root_element.Branch:
+                if hasattr(branch_elem, 'FullProductName'):
+                    branches.append(self._handle_branches_recursive(branch_elem))
                 else:
                     branches.append({
-                        'name': branch.attrib['Name'],
-                        'category': branch.attrib['Type'],
-                        'branches': self._handle_branches_recursive(branch)
+                        'name': branch_elem.attrib['Name'],
+                        'category': branch_elem.attrib['Type'],
+                        'branches': self._handle_branches_recursive(branch_elem)
                     })
 
             return branches

--- a/cvrf2csaf/section_handlers/product_tree.py
+++ b/cvrf2csaf/section_handlers/product_tree.py
@@ -1,0 +1,39 @@
+import logging
+import re
+import sys
+from operator import itemgetter
+from typing import Tuple
+from ..common.common import SectionHandler
+from ..common.utils import get_utc_timestamp
+
+
+
+class ProductTree(SectionHandler):
+    """ Responsible for converting the ProductTree section """
+
+    def _process_mandatory_elements(self, root_element):
+        """ There are no mandatory elements in the ProductTree section """
+        pass
+
+    def _process_optional_elements(self, root_element):
+        if hasattr(root_element, 'FullProductName'):
+            full_product_names = []
+            for full_product_name in root_element.FullProductName:
+                full_product_names.append({
+                    'product_id': full_product_name.attrib['ProductID'],
+                    'name': full_product_name.text,
+                    'product_identification_helper': {'cpe': full_product_name.attrib['CPE']},
+                })
+
+            self.csaf['full_product_names'] = full_product_names
+
+        # if hasattr(root_element, 'Relationship'):
+        #     relationships = []
+        #     for relationship in root_element.Relationship:
+        #         relationships.append({
+        #             # optional CPE attribute in CVRF is omitted (not present in CSAF specification)
+        #             # 'product_id': full_product_name.attrib['ProductID'],
+        #             # 'name': full_product_name.text,
+        #         })
+        #
+        #     self.csaf['relationships'] = relationships


### PR DESCRIPTION
Closes #26 

All the 4 subsections were implemented (Relationships, FullProductNames, Branches, ProductGroups).

Tested with some real-world or crafted examples.

Conformance target `/product_tree/relationships[]` also implemented, can be checked after merging the PR.

[/product_tree/relationships[]](https://github.com/csaf-tools/CVRF-CSAF-Converter/issues/4)