### PR TITLE
Document references fix.

### DIFF
--- a/cvrf2csaf/section_handlers/document_references.py
+++ b/cvrf2csaf/section_handlers/document_references.py
@@ -19,9 +19,6 @@ class DocumentReferences(SectionHandler):
             else:  # TODO: is this really needed here? `category` fields is not mandatory in CSAF
                 ref_csaf['category'] = 'external'  # default behaviour
 
-            if ref_csaf['category'] not in ['external', 'self']:
-                logging.warning(f'DocumentReferences->category {ref_csaf["category"]} must be external or self!')
-
             references.append(ref_csaf)
 
         self.csaf = references

--- a/cvrf2csaf/section_handlers/document_references.py
+++ b/cvrf2csaf/section_handlers/document_references.py
@@ -9,22 +9,20 @@ class DocumentReferences(SectionHandler):
     def _process_mandatory_elements(self, root_element):
 
         references = []
-        if hasattr(root_element, 'Reference'):
-            for ref in root_element.Reference:
-                ref_csaf = dict()
-                if 'Type' not in ref.attrib or len(ref.attrib['Type']) < 2:
-                    ref_csaf['category'] = 'external' # default behaviour
-                else:
-                    ref_csaf['category'] = str(ref.attrib['Type'])
 
-                if ref_csaf['category'] not in ['external', 'self']:
-                    logging.warn(f'DocumentReferences->category {ref_csaf["category"]} must be external or self!')
+        for reference in root_element.Reference:
+            ref_csaf = {'summary': reference.Description.text,
+                        'url': reference.URL.text}
 
-                if hasattr(ref, 'Description'):
-                    ref_csaf['summary'] = ref.Description.text
-                if hasattr(ref, 'URL'):
-                    ref_csaf['url'] = ref.URL.text
-                references.append(ref_csaf)
+            if reference.attrib.get('Type'):
+                ref_csaf['category'] = reference.attrib['Type'].lower()
+            else:  # TODO: is this really needed here? `category` fields is not mandatory in CSAF
+                ref_csaf['category'] = 'external'  # default behaviour
+
+            if ref_csaf['category'] not in ['external', 'self']:
+                logging.warning(f'DocumentReferences->category {ref_csaf["category"]} must be external or self!')
+
+            references.append(ref_csaf)
 
         self.csaf = references
 


### PR DESCRIPTION
from xsd schema:
```
        <xs:element name="DocumentReferences" minOccurs="0" maxOccurs="1">
          <xs:annotation>
            <xs:documentation xml:lang="en">This meta-container should include references to any conferences, papers, advisories, and other resources that are related and considered to be of value to the document consumer.</xs:documentation>
          </xs:annotation>
          <xs:complexType>
            <xs:sequence>
              <xs:element name="Reference" minOccurs="1" maxOccurs="unbounded">
                <xs:annotation>
                  <xs:documentation xml:lang="en">Related documents to the CSAF CVRF document.</xs:documentation>
                </xs:annotation>
                <xs:complexType>
                  <xs:sequence>
                    <xs:element name="URL" type="xs:anyURI" minOccurs="1" maxOccurs="1">
                      <xs:annotation>
                        <xs:documentation xml:lang="en">The URL of the related document.</xs:documentation>
                      </xs:annotation>
                    </xs:element>
                    <xs:element name="Description" minOccurs="1" maxOccurs="1">
                      <xs:annotation>
                        <xs:documentation xml:lang="en">The description of the related document.</xs:documentation>
                      </xs:annotation>
                      <xs:complexType>
                        <xs:simpleContent>
                          <xs:extension base="cvrf-common:localizedString"/>
                        </xs:simpleContent>
                      </xs:complexType>
                    </xs:element>
                  </xs:sequence>
                  <xs:attribute name="Type" type="cvrf-common:ReferenceTypeEnum" default="External">
                    <xs:annotation>
                      <xs:documentation xml:lang="en">Enumerated type value of reference relative to this document.</xs:documentation>
                    </xs:annotation>
                  </xs:attribute>
                </xs:complexType>
              </xs:element>
            </xs:sequence>
          </xs:complexType>
        </xs:element>
```
and
```
  <xs:simpleType name="ReferenceTypeEnum">
    <xs:annotation>
      <xs:documentation xml:lang="en">Types enumerating the type of reference
        document</xs:documentation>
    </xs:annotation>
    <xs:restriction base="xs:token">
      <xs:enumeration value="External">
        <xs:annotation>
          <xs:documentation xml:lang="en">This document is an external reference to the current
            vulnerability.</xs:documentation>
        </xs:annotation>
      </xs:enumeration>
      <xs:enumeration value="Self">
        <xs:annotation>
          <xs:documentation xml:lang="en">This document is a reference to this same
            vulnerability.</xs:documentation>
        </xs:annotation>
      </xs:enumeration>
    </xs:restriction>
  </xs:simpleType>
```
 - `Reference` element is mandatory -> `if hasattr(root_element, 'Reference'):` not necessary
 - `Description` and `URL` is mandatory -> ` if hasattr(ref, <elem>):` not necessary + dict literal
 - use `.lower()` (sometimes even `.replace(' ', '_')`) when converting enums from CVRF to CSAF
