### PR TITLE
Finalize handling the revision history

### DIFF
--- a/cvrf2csaf/common/utils.py
+++ b/cvrf2csaf/common/utils.py
@@ -43,7 +43,7 @@ def get_config_from_file() -> dict:
         with open(path_to_conf, 'r') as f:
             config = yaml.safe_load(f)
 
-        for key in ['force', 'force_insert_current_version_into_revision_history']:
+        for key in ['force', 'fix_insert_current_version_into_revision_history']:
             if key in config.keys():
                 config[key] = handle_boolean_config_values(key=key, val=config[key])
 

--- a/cvrf2csaf/common/utils.py
+++ b/cvrf2csaf/common/utils.py
@@ -43,7 +43,7 @@ def get_config_from_file() -> dict:
         with open(path_to_conf, 'r') as f:
             config = yaml.safe_load(f)
 
-        for key in ['force', 'force_update_revision_history']:
+        for key in ['force', 'force_insert_current_version_into_revision_history']:
             if key in config.keys():
                 config[key] = handle_boolean_config_values(key=key, val=config[key])
 

--- a/cvrf2csaf/config/config.yaml
+++ b/cvrf2csaf/config/config.yaml
@@ -12,7 +12,7 @@ publisher_name: Publisher Name
 publisher_namespace: https://example.com
 
 # Document Tracking
-force_update_revision_history: false
+force_insert_current_version_into_revision_history: false
 
 # Document References
 force_insert_default_reference_category: true

--- a/cvrf2csaf/config/config.yaml
+++ b/cvrf2csaf/config/config.yaml
@@ -12,7 +12,7 @@ publisher_name: Publisher Name
 publisher_namespace: https://example.com
 
 # Document Tracking
-force_insert_current_version_into_revision_history: false
+fix_insert_current_version_into_revision_history: false
 
 # Document References
 force_insert_default_reference_category: true

--- a/cvrf2csaf/cvrf2csaf.py
+++ b/cvrf2csaf/cvrf2csaf.py
@@ -206,7 +206,7 @@ def main():
                         help="Namespace of the publisher.")
 
     # Document Tracking args
-    parser.add_argument('--force-insert-current-version-into-revision-history', action='store_const', const='cmd-arg-entered',
+    parser.add_argument('--fix-insert-current-version-into-revision-history', action='store_const', const='cmd-arg-entered',
                         help="If the current version is not present in the revision history "
                              "the current version is added to the revision history. Also warning is produced. By default, "
                              "an error is produced.")
@@ -219,8 +219,8 @@ def main():
     config.update(args)
 
     # Boolean optional arguments that are also present in config need special treatment
-    if config['force_insert_current_version_into_revision_history'] == 'cmd-arg-entered':
-        config['force_insert_current_version_into_revision_history'] = True
+    if config['fix_insert_current_version_into_revision_history'] == 'cmd-arg-entered':
+        config['fix_insert_current_version_into_revision_history'] = True
     if config['force'] == 'cmd-arg-entered':
         config['force'] = True
 

--- a/cvrf2csaf/cvrf2csaf.py
+++ b/cvrf2csaf/cvrf2csaf.py
@@ -196,7 +196,7 @@ def main():
                         help="CVRF JSON output dir to write to. Filename is derived from /document/tracking/id.", metavar='PATH')
     parser.add_argument('--print', dest='print', action='store_true', default=False,
                         help="Additionally prints JSON output on command line.")
-    parser.add_argument('--force', action='store_true', dest='force',
+    parser.add_argument('--force', action='store_const', const='cmd-arg-entered',
                         help="If used, the converter produces output that is invalid "
                              "(use case: convert to JSON, fix the errors manual, e.g. in Secvisogram.")
 
@@ -206,11 +206,10 @@ def main():
                         help="Namespace of the publisher.")
 
     # Document Tracking args
-    parser.add_argument('--force-update-revision-history', action='store_const', const='cmd-arg-entered',
-                        help="If the current version is not present in the revision history AND the difference "
-                             "between the current version and the most recent revision is more than one version, "
+    parser.add_argument('--force-insert-current-version-into-revision-history', action='store_const', const='cmd-arg-entered',
+                        help="If the current version is not present in the revision history "
                              "the current version is added to the revision history. Also warning is produced. By default, "
-                             "the current version is added only if the difference is one version.")
+                             "an error is produced.")
 
     args = {k: v for k, v in vars(parser.parse_args()).items() if v is not None}
 
@@ -219,9 +218,11 @@ def main():
     # Update & rewrite config file values with the ones from command line arguments
     config.update(args)
 
-    # Boolean optional argument need special treatment
-    if config['force_update_revision_history'] == 'cmd-arg-entered':
-        config['force_update_revision_history'] = True
+    # Boolean optional arguments that are also present in config need special treatment
+    if config['force_insert_current_version_into_revision_history'] == 'cmd-arg-entered':
+        config['force_insert_current_version_into_revision_history'] = True
+    if config['force'] == 'cmd-arg-entered':
+        config['force'] = True
 
     if not os.path.isfile(config.get('input_file')):
         critical_exit(f'Input file not found, check the path: {config.get("input_file")}')

--- a/cvrf2csaf/section_handlers/document_tracking.py
+++ b/cvrf2csaf/section_handlers/document_tracking.py
@@ -18,8 +18,8 @@ class DocumentTracking(SectionHandler):
         super().__init__()
         self.cvrf2csaf_name = config.get('cvrf2csaf_name')
         self.cvrf2csaf_version = pkg_version
-        self.force_insert_current_version_into_revision_history \
-            = config.get('force_insert_current_version_into_revision_history')
+        self.fix_insert_current_version_into_revision_history \
+            = config.get('fix_insert_current_version_into_revision_history')
 
     def _process_mandatory_elements(self, root_element):
         self.csaf['id'] = root_element.Identification.ID.text
@@ -71,7 +71,7 @@ class DocumentTracking(SectionHandler):
 
     def _add_current_revision_to_history(self, root_element, revision_history) -> None:
         """
-        If the current version is missing in Revision history and --force-insert-current-version-into-revision-history is True,
+        If the current version is missing in Revision history and --fix-insert-current-version-into-revision-history is True,
         the current version is added to the history.
         """
 
@@ -124,14 +124,14 @@ class DocumentTracking(SectionHandler):
         missing_latest_version_in_history = False
         # Do we miss the current version in the revision history?
         if not [rev for rev in revision_history if rev['number'] == version]:
-            if self.force_insert_current_version_into_revision_history:
-                logging.warning('Forcing update of the revision history and adding the current version. '
+            if self.fix_insert_current_version_into_revision_history:
+                logging.warning('Trying to fix the revision history by adding the current version. '
                                 'This may lead to inconsistent history. This happens because '
-                                '--force-insert-current-version-into-revision-history is used. ')
+                                '--fix-insert-current-version-into-revision-history is used. ')
                 self._add_current_revision_to_history(root_element, revision_history)
             else:
                 logging.error('Current version is missing in revision history. '
-                              'This can be fixed by using --force-insert-current-version-into-revision-history')
+                              'This can be fixed by using --fix-insert-current-version-into-revision-history')
                 missing_latest_version_in_history = True
                 self.error_occurred = True
 
@@ -142,7 +142,7 @@ class DocumentTracking(SectionHandler):
                 revision_history, version = self._reindex_versions_to_integers(root_element, revision_history)
             else:
                 logging.error('Can not reindex revision history to integers because of missing the current version. '
-                              'This can be fixed with --force-insert-current-version-into-revision-history')
+                              'This can be fixed with --fix-insert-current-version-into-revision-history')
                 self.error_occurred = True
 
         # cleanup extra vars

--- a/cvrf2csaf/section_handlers/document_tracking.py
+++ b/cvrf2csaf/section_handlers/document_tracking.py
@@ -18,7 +18,8 @@ class DocumentTracking(SectionHandler):
         super().__init__()
         self.cvrf2csaf_name = config.get('cvrf2csaf_name')
         self.cvrf2csaf_version = pkg_version
-        self.force_update_revision_history = config.get('force_update_revision_history')
+        self.force_insert_current_version_into_revision_history \
+            = config.get('force_insert_current_version_into_revision_history')
 
     def _process_mandatory_elements(self, root_element):
         self.csaf['id'] = root_element.Identification.ID.text
@@ -26,7 +27,7 @@ class DocumentTracking(SectionHandler):
         self.csaf['initial_release_date'] = get_utc_timestamp(root_element.InitialReleaseDate.text)
         self.csaf['status'] = self.tracking_status_mapping[root_element.Status.text]
 
-        revision_history, version = self._process_revision_history_and_version(root_element)
+        revision_history, version = self._handle_revision_history_and_version(root_element)
         self.csaf['revision_history'] = revision_history
         self.csaf['version'] = version
 
@@ -70,36 +71,10 @@ class DocumentTracking(SectionHandler):
 
     def _add_current_revision_to_history(self, root_element, revision_history) -> None:
         """
-        If the current version is missing in Revision history, the current version is tried to be added
-        to the history. The result also depends on the force_update_revision_history attribute
-
-        Calls critical_exit if could not be handled
+        If the current version is missing in Revision history and --force-insert-current-version-into-revision-history is True,
+        the current version is added to the history.
         """
 
-        current_version = self._as_int_tuple(root_element.Version.text)
-        latest_history_revision = self._as_int_tuple(revision_history[-1]['number'])
-
-        if len(current_version) != len(latest_history_revision):
-            log_msg = 'Mixed formats for the current version and the last revision from history.'
-            logging.error(log_msg)  # Todo: handle force parameter here
-
-        if current_version[-1] - latest_history_revision[-1] > 1:
-            if self.force_update_revision_history is True:
-                logging.warning('Forcing update of the revision history and adding the current version. '
-                                'This may lead to inconsistent history.')
-            else:
-                SectionHandler.error_occurred = True
-                logging.error('Too big difference between the current version and the last revision in history. '
-                                    'This can be fixed by using --force-update-revision-history')
-
-        elif current_version[-1] - latest_history_revision[-1] == 1:
-            logging.warning('Adding the current version to the revision history (difference is only 1 version).')
-
-        else:
-            SectionHandler.error_occurred = True
-            logging.error('Unexpected case occured when trying to fix the revision history.')
-
-        # All the conditions were met, now add the actual revision to the history
         revision_history.append(
             {
                 'date': get_utc_timestamp(root_element.CurrentReleaseDate.text),
@@ -126,7 +101,7 @@ class DocumentTracking(SectionHandler):
 
         return revision_history_sorted, version
 
-    def _process_revision_history_and_version(self, root_element):
+    def _handle_revision_history_and_version(self, root_element):
         # preprocess the data
         revision_history = []
         for revision in root_element.RevisionHistory.Revision:
@@ -143,17 +118,32 @@ class DocumentTracking(SectionHandler):
                 }
             )
 
+        # Just copy over the version
+        version = root_element.Version.text
+
+        missing_latest_version_in_history = False
         # Do we miss the current version in the revision history?
-        if not [rev for rev in revision_history if rev['number'] == root_element.Version.text]:
-            self._add_current_revision_to_history(root_element, revision_history)
+        if not [rev for rev in revision_history if rev['number'] == version]:
+            if self.force_insert_current_version_into_revision_history:
+                logging.warning('Forcing update of the revision history and adding the current version. '
+                                'This may lead to inconsistent history. This happens because '
+                                '--force-insert-current-version-into-revision-history is used. ')
+                self._add_current_revision_to_history(root_element, revision_history)
+            else:
+                logging.error('Current version is missing in revision history. '
+                              'This can be fixed by using --force-insert-current-version-into-revision-history')
+                missing_latest_version_in_history = True
+                self.error_occurred = True
 
         # handle corresponding part of Conformance Clause 5: CVRF CSAF converter
         # that is: some version numbers in revision_history don't match semantic versioning
         if not self.check_for_version_t(revision_history):
-            revision_history, version = self._reindex_versions_to_integers(root_element, revision_history)
-        else:
-            # Just copy over the version
-            version = root_element.Version.text
+            if not missing_latest_version_in_history:
+                revision_history, version = self._reindex_versions_to_integers(root_element, revision_history)
+            else:
+                logging.error('Can not reindex revision history to integers because of missing the current version. '
+                              'This can be fixed with --force-insert-current-version-into-revision-history')
+                self.error_occurred = True
 
         # cleanup extra vars
         for revision in revision_history:


### PR DESCRIPTION
Implemented as designed in #25 

- Keeping the `force` prefix instead of `fix` to be consistent with other options
- Renamed the function from `process_*` to `handle_*`, to be consistent with other section handlers
- As this also affects the Conformance target regarding re-indexing versions, I chose this approach:
  - If the current version is missing in the revision history and it wasn't added by the `force-*` flag, the reindexing to integers is skipped, effectively producing 2 errors here (see [commit](https://github.com/csaf-tools/CVRF-CSAF-Converter/pull/67/commits/f3eaada9ff83c91d695b7935691ca3859432ee45#diff-30f490ba47277c680d6eda18935b69739e10dd472033f20678bac163fe3372faR144))