### PR TITLE
CPE regex, multiple cvss v3 versions

### DIFF
--- a/cvrf2csaf/cvrf2csaf.py
+++ b/cvrf2csaf/cvrf2csaf.py
@@ -35,7 +35,7 @@ class DocumentHandler:
     """
 
     TOLERATED_ERRORS_SUBSTR = ["}ScoreSetV3': This element is not expected. Expected is one of ( {http://docs.oasis-open.org/csaf/ns/csaf-cvrf/v1.2/vuln}ScoreSetV2, {http://docs.oasis-open.org/csaf/ns/csaf-cvrf/v1.2/vuln}ScoreSetV3 ).",
-                        "ScoreSetV3': This element is not expected. Expected is ( {http://docs.oasis-open.org/csaf/ns/csaf-cvrf/v1.2/vuln}ScoreSetV3 )."]
+                        "}ScoreSetV3': This element is not expected. Expected is ( {http://docs.oasis-open.org/csaf/ns/csaf-cvrf/v1.2/vuln}ScoreSetV3 )."]
 
     SCHEMA_FILE = 'schemata/cvrf/1.2/cvrf.xsd'
     CATALOG_FILE = 'schemata/catalog_1_2.xml'

--- a/cvrf2csaf/cvrf2csaf.py
+++ b/cvrf2csaf/cvrf2csaf.py
@@ -35,7 +35,8 @@ class DocumentHandler:
     """
 
     TOLERATED_ERRORS_SUBSTR = ["}ScoreSetV3': This element is not expected. Expected is one of ( {http://docs.oasis-open.org/csaf/ns/csaf-cvrf/v1.2/vuln}ScoreSetV2, {http://docs.oasis-open.org/csaf/ns/csaf-cvrf/v1.2/vuln}ScoreSetV3 ).",
-                        "}ScoreSetV3': This element is not expected. Expected is ( {http://docs.oasis-open.org/csaf/ns/csaf-cvrf/v1.2/vuln}ScoreSetV3 )."]
+                        "}ScoreSetV3': This element is not expected. Expected is ( {http://docs.oasis-open.org/csaf/ns/csaf-cvrf/v1.2/vuln}ScoreSetV3 ).",
+                        "is not accepted by the pattern '[c][pP][eE]:/[AHOaho]?(:[A-Za-z0-9\._\-~%]*){0,6}'."]
 
     SCHEMA_FILE = 'schemata/cvrf/1.2/cvrf.xsd'
     CATALOG_FILE = 'schemata/catalog_1_2.xml'

--- a/cvrf2csaf/section_handlers/vulnerability.py
+++ b/cvrf2csaf/section_handlers/vulnerability.py
@@ -3,6 +3,7 @@ import bisect
 import re
 
 from collections import defaultdict
+from itertools import chain
 
 from ..common.common import SectionHandler
 from ..section_handlers.document_acknowledgments import Acknowledgments
@@ -119,7 +120,8 @@ class Vulnerability(SectionHandler):
 
         # Parse all input elements except ProductID
         # note: baseScore is always present since it's mandatory for the input
-        cvss_score = {csaf: getattr(score_set_element, cvrf).text for cvrf, csaf in mapping.items() if hasattr(score_set_element, cvrf)}
+        cvss_score = {csaf: getattr(score_set_element, cvrf).text for cvrf, csaf in mapping.items() if
+                      hasattr(score_set_element, cvrf)}
 
         # Convert all possible scores to float
         scores = ['baseScore', 'temporalScore', 'environmentalScore']
@@ -180,6 +182,33 @@ class Vulnerability(SectionHandler):
 
         return score
 
+    @staticmethod
+    def _remove_cvssv3_duplicates(scores):
+        """
+        Removes products/cvssv3.x score sets for products having both v3.0 and v3.1 score. Three step approach:
+         - find products having both versions specified
+         - remove those products from score set with version 3.0
+         - removes score sets with no products
+        """
+        # STEP 1
+        products_v3_1 = set(chain.from_iterable([score_set['products'] for score_set in scores if
+                                                 'cvss_v3' in score_set and score_set['cvss_v3']['version'] == '3.1']))
+        products_v3_0 = set(chain.from_iterable([score_set['products'] for score_set in scores if
+                                                 'cvss_v3' in score_set and score_set['cvss_v3']['version'] == '3.0']))
+
+        both_versions = products_v3_0.intersection(products_v3_1)
+
+        # STEP 2
+        for score_set in scores:
+            if 'cvss_v3' in score_set and score_set['cvss_v3']['version'] == '3.0':
+                score_set['products'] = [product for product in score_set['products'] if product not in both_versions]
+
+        # STEP 3
+        scores = [score_set for score_set in scores if len(score_set['products']) > 0]
+
+        return scores
+
+
     def _handle_scores(self, root_element, product_status):
         scores = []
 
@@ -192,6 +221,8 @@ class Vulnerability(SectionHandler):
                 score = self._parse_score_set(score_set, mapping, score_version, target, product_status)
                 if score is not None:
                     scores.append(score)
+
+        scores = self._remove_cvssv3_duplicates(scores)
 
         return scores
 

--- a/cvrf2csaf/section_handlers/vulnerability.py
+++ b/cvrf2csaf/section_handlers/vulnerability.py
@@ -136,7 +136,7 @@ class Vulnerability(SectionHandler):
         # if we have ProductID element(s), parse and use
         if hasattr(score_set_element, 'ProductID'):
             product_ids = [product_id.text for product_id in score_set_element.ProductID]
-        # one of the conversion rules specifies what to in case of missing ProductID element
+        # one of the conversion rules specifies what to do in case of missing ProductID element
         elif product_status:
             states = ('known_affected', 'first_affected', 'last_affected')
             product_ids = list(set(product_id for state in states for product_id in product_status.get(state, [])))
@@ -157,6 +157,12 @@ class Vulnerability(SectionHandler):
                 SectionHandler.error_occurred = True
                 logging.error('No CVSS vector string found on the input.')
 
+        # DETERMINE CVSS v 3.x from namespace
+        cvss_3_regex = '.*cvss-v(3\.[01]).*'
+        match = re.match(cvss_3_regex, score_set_element.tag)
+        if match:
+            version = match.groups()[0]
+
         # DETERMINE CVSS v 3.x from vector if present
         if 'vectorString' in cvss_score and json_property == 'cvss_v3':
             regex = "CVSS:(3\.[01]).*" # TODO: implement full regex check here?
@@ -165,7 +171,6 @@ class Vulnerability(SectionHandler):
                 SectionHandler.error_occurred = True
                 logging.error(f'CVSS vector {cvss_score["vectorString"]} is not valid.')
             else:
-
                 version = match.groups()[0]
 
         cvss_score['version'] = version
@@ -183,7 +188,7 @@ class Vulnerability(SectionHandler):
             ('ScoreSetV3', self.cvss_v3_mapping, self.default_CVSS3_version, 'cvss_v3'),
         )
         for score_variant, mapping, score_version, target in score_variants:
-            for score_set in getattr(root_element, score_variant, []):
+            for score_set in root_element.findall(f'{{*}}{score_variant}'):
                 score = self._parse_score_set(score_set, mapping, score_version, target, product_status)
                 if score is not None:
                     scores.append(score)

--- a/cvrf2csaf/section_handlers/vulnerability.py
+++ b/cvrf2csaf/section_handlers/vulnerability.py
@@ -120,8 +120,7 @@ class Vulnerability(SectionHandler):
 
         # Parse all input elements except ProductID
         # note: baseScore is always present since it's mandatory for the input
-        cvss_score = {csaf: getattr(score_set_element, cvrf).text for cvrf, csaf in mapping.items() if
-                      hasattr(score_set_element, cvrf)}
+        cvss_score = {csaf: getattr(score_set_element, cvrf).text for cvrf, csaf in mapping.items() if hasattr(score_set_element, cvrf)}
 
         # Convert all possible scores to float
         scores = ['baseScore', 'temporalScore', 'environmentalScore']

--- a/examples/1.2/cvrf_example_vulnerabilities.xml
+++ b/examples/1.2/cvrf_example_vulnerabilities.xml
@@ -165,22 +165,24 @@
     <ProductStatuses>
       <Status Type="Known Affected">
         <ProductID>CVRFPID-223156</ProductID>
+        <ProductID>CVRFPID-223155</ProductID>
       </Status>
     </ProductStatuses>
     <CVSSScoreSets>
-      <ScoreSetV2>
-        <BaseScoreV2>7.5</BaseScoreV2>
-        <VectorV2>AV:A/AC:M/Au:N/C:N/I:C/A:P</VectorV2>
-      </ScoreSetV2>
-      <ScoreSetV3>
-        <BaseScoreV3>7.5</BaseScoreV3>
-        <VectorV3>CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H</VectorV3>
-      </ScoreSetV3>
-      <ScoreSetV3 xmlns="https://www.first.org/cvss/cvss-v3.0.xsd">
-        <BaseScoreV3>7.5</BaseScoreV3>
-        <VectorV3>CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H</VectorV3>
-      </ScoreSetV3>
-      </CVSSScoreSets>
+          <ScoreSetV2>
+            <BaseScoreV2>7.5</BaseScoreV2>
+            <VectorV2>AV:A/AC:M/Au:N/C:N/I:C/A:P</VectorV2>
+          </ScoreSetV2>
+          <ScoreSetV3>
+            <BaseScoreV3>7.5</BaseScoreV3>
+            <VectorV3>CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H</VectorV3>
+          </ScoreSetV3>
+          <ScoreSetV3 xmlns="https://www.first.org/cvss/cvss-v3.0.xsd">
+            <BaseScoreV3>7.5</BaseScoreV3>
+            <VectorV3>CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H</VectorV3>
+            <ProductID>CVRFPID-223155</ProductID>
+          </ScoreSetV3>
+    </CVSSScoreSets>
     <Remediations>
       <Remediation Type="Workaround">
         <Description>There are no workarounds that ...</Description>

--- a/examples/1.2/cvrf_example_vulnerabilities.xml
+++ b/examples/1.2/cvrf_example_vulnerabilities.xml
@@ -57,7 +57,7 @@
       <Branch Name="... Appliances" Type="Product Name">
         <Branch Name="1.0" Type="Product Version">
           <Branch Name=".0" Type="Service Pack">
-                <FullProductName ProductID="CVRFPID-223152">...
+                <FullProductName ProductID="CVRFPID-223152" CPE="cpe:2.3:a:gemalto:sentinel_ldk_rte:3.0:*:*:*:*:*:*:*">...
                   AppY 1.0.0</FullProductName>
           </Branch>
           <Branch Name="(2)" Type="Service Pack">
@@ -173,6 +173,10 @@
         <VectorV2>AV:A/AC:M/Au:N/C:N/I:C/A:P</VectorV2>
       </ScoreSetV2>
       <ScoreSetV3>
+        <BaseScoreV3>7.5</BaseScoreV3>
+        <VectorV3>CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H</VectorV3>
+      </ScoreSetV3>
+      <ScoreSetV3 xmlns="https://www.first.org/cvss/cvss-v3.0.xsd">
         <BaseScoreV3>7.5</BaseScoreV3>
         <VectorV3>CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H</VectorV3>
       </ScoreSetV3>


### PR DESCRIPTION
- we now tolerate CPE regex validation error

- method `_remove_cvssv3_duplicates` added when both cvss v3.0 and v3.1 scores are 

> provided: /vulnerabilities[]/scores[]: If there are CVSS v3.0 and CVSS v3.1 Vectors available for the same product, the CVRF CSAF converter discards the CVSS v3.0 information and provide in CSAF only the CVSS v3.1 information.

### Example: 
input snippet:
```
    <ProductStatuses>
      <Status Type="Known Affected">
        <ProductID>CVRFPID-223156</ProductID>
        <ProductID>CVRFPID-223155</ProductID>
      </Status>
    </ProductStatuses>
    <CVSSScoreSets>
          <ScoreSetV2>
            <BaseScoreV2>7.5</BaseScoreV2>
            <VectorV2>AV:A/AC:M/Au:N/C:N/I:C/A:P</VectorV2>
          </ScoreSetV2>
          <ScoreSetV3>
            <BaseScoreV3>7.5</BaseScoreV3>
            <VectorV3>CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H</VectorV3>
          </ScoreSetV3>
          <ScoreSetV3 xmlns="https://www.first.org/cvss/cvss-v3.0.xsd">
            <BaseScoreV3>7.5</BaseScoreV3>
            <VectorV3>CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H</VectorV3>
            <ProductID>CVRFPID-223155</ProductID>
          </ScoreSetV3>
    </CVSSScoreSets>
```
would previously resulted into:

```
    [
    {
       "cvss_v2":{
          "baseScore":7.5,
          "vectorString":"AV:A/AC:M/Au:N/C:N/I:C/A:P",
          "version":"2.0"
       },
       "products":[
          "CVRFPID-223155",
          "CVRFPID-223156"
       ]
    },
    {
       "cvss_v3":{
          "baseScore":7.5,
          "vectorString":"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
          "baseSeverity":"HIGH",
          "version":"3.1"
       },
       "products":[
          "CVRFPID-223155",
          "CVRFPID-223156"
       ]
    },
    {
       "cvss_v3":{
          "baseScore":7.5,
          "vectorString":"CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
          "baseSeverity":"HIGH",
          "version":"3.0"
       },
       "products":[
          "CVRFPID-223155"
       ]
    }
 ]
```

with this fix results in:
```

       "scores": [
        {
          "cvss_v2": {
            "baseScore": 7.5,
            "vectorString": "AV:A/AC:M/Au:N/C:N/I:C/A:P",
            "version": "2.0"
          },
          "products": [
            "CVRFPID-223156",
            "CVRFPID-223155"
          ]
        },
        {
          "cvss_v3": {
            "baseScore": 7.5,
            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
            "baseSeverity": "HIGH",
            "version": "3.1"
          },
          "products": [
            "CVRFPID-223156",
            "CVRFPID-223155"
          ]
        }
      ]
```