### PR TITLE
Allow PyYAML > 6, current version is 6.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 lxml>=4.7,<5
-PyYAML>=5.0,<7
+PyYAML>=6.0,<7
 jsonschema>=4.4.0,<5
 turvallisuusneuvonta

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ include_package_data = True
 python_requires = >=3.6
 install_requires =
     lxml>=4.7,<5
-    PyYAML>=5.0,<7
+    PyYAML>=6.0,<7
     jsonschema>=4.4.0,<5
     turvallisuusneuvonta
 


### PR DESCRIPTION
PyYAML < 6.0.2 is not compatible with Cython 3.x which leads to build failures on e.g. Debian bookworm.