### PR TITLE
Update python versions in .github/workflows/pylint.yml

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-lxml>=4.7,<5
+lxml>=5.0,<6
 PyYAML>=5.0,<6
 jsonschema>=4.4.0,<5
 turvallisuusneuvonta

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ zip_safe = False
 include_package_data = True
 python_requires = >=3.6
 install_requires =
-    lxml>=4.7,<5
+    lxml>=5.0,<6
     PyYAML>=5.0,<6
     jsonschema>=4.4.0,<5
     turvallisuusneuvonta


### PR DESCRIPTION
Python 3.8 has reached end of life. Current major version is 3.13.

This fixes #121
