### PR TITLE
Fix pylint messages und product_ids conversion

### DIFF
--- a/cvrf2csaf/section_handlers/vulnerability.py
+++ b/cvrf2csaf/section_handlers/vulnerability.py
@@ -110,17 +110,24 @@ class Vulnerability(SectionHandler):
             if hasattr(remediation_elem, 'GroupID'):
                 remediation['group_ids'] = [group_id.text for group_id in remediation_elem.GroupID]
 
-            # one of the conversion rules specifies what to do in case of missing
-            # ProductIDs and GroupIDs
+            # The remediation object must contain at least one of
+            # product_ids and group_ids (see 3.2.3.12 Vulnerabilities
+            # Property - Remediations)
             if 'product_ids' not in remediation and 'group_ids' not in remediation:
+                # If neither is present at this point, we may be able to
+                # determine the product_ids from product_status.
+                # (see 9.1.5 Conformance Clause 5: CVRF CSAF converter)
                 if product_status:
                     product_ids = Vulnerability._parse_affected_product_ids(
                         product_status)
                     if len(product_ids) != 0:
                         remediation['product_ids'] = product_ids
-                    else:
-                        SectionHandler.error_occurred = True
-                        logging.error('No product_ids or group_ids entries for remediation.')
+
+                if 'product_ids' not in remediation:
+                    # If product_status did not contain product_ids,
+                    # print an error
+                    SectionHandler.error_occurred = True
+                    logging.error('No product_ids or group_ids entries for remediation.')
 
             if 'Date' in remediation_elem.attrib:
                 remediation['date'] = get_utc_timestamp(remediation_elem.attrib['Date'])

--- a/cvrf2csaf/section_handlers/vulnerability.py
+++ b/cvrf2csaf/section_handlers/vulnerability.py
@@ -116,11 +116,11 @@ class Vulnerability(SectionHandler):
                 if product_status:
                     product_ids = Vulnerability._parse_affected_product_ids(
                         product_status)
-            if len(product_ids) != 0:
-                remediation['product_ids'] = product_ids
-            else:
-                SectionHandler.error_occurred = True
-                logging.error('No product_ids or group_ids entries for remediation.')
+                    if len(product_ids) != 0:
+                        remediation['product_ids'] = product_ids
+                    else:
+                        SectionHandler.error_occurred = True
+                        logging.error('No product_ids or group_ids entries for remediation.')
 
             if 'Date' in remediation_elem.attrib:
                 remediation['date'] = get_utc_timestamp(remediation_elem.attrib['Date'])

--- a/cvrf2csaf/section_handlers/vulnerability.py
+++ b/cvrf2csaf/section_handlers/vulnerability.py
@@ -145,7 +145,7 @@ class Vulnerability(SectionHandler):
             set(affected_product_id for state in states for affected_product_id
                 in product_status.get(state, [])))
 
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
     def _parse_score_set(self, score_set_element, mapping, version, json_property, product_status):
         """Parses ScoreSetV2 or ScoreSetV3 element."""
 


### PR DESCRIPTION
This PR contains two changes that fix the pylint messages:

 * a1a5a0a fixes the harmless message about too many positional arguments with a pylint pragma

 * b4ccdd0 fixes the problem with the product_ids variable.

The latter is the more important one because it fixes issue #123. It also changes the output of the converter:

 * `examples/1.2/cvrf_example_c.xml` now produces a CSAF file with a `"vulnerabilities"` array.

 * `examples/1.2/cvrf_example_e.xml` now fails with:

        ERROR - Mandatory test is_valid_defined_product_ids failed.
