### PR TITLE
Pylint workflow: Update action and minimize permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions: {}
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]


### PR DESCRIPTION
Update `actions/setup-python` to the latest version

For the pylint action, the resulting permissions are just:
- Metadata: read

Fixes https://github.com/csaf-tools/CVRF-CSAF-Converter/issues/117