### PR TITLE
Fix running the tests from other directories

### DIFF
--- a/tests/test_cvrf_full/test_cvrf_full.py
+++ b/tests/test_cvrf_full/test_cvrf_full.py
@@ -1,9 +1,10 @@
 """File containing full CVRF test."""
 import json
 from contextlib import suppress
+from pathlib import Path
 
 
-with open('./test_cvrf_full.json', encoding='utf-8') as f:
+with open(Path(__file__).parent / 'test_cvrf_full.json', encoding='utf-8') as f:
     csaf = json.loads(f.read())
 
 


### PR DESCRIPTION
Running `pytest` (or calling the test file itseld) in the top directory now can run the tests or from within the `tests` directory.

Previously, the working directory had to be exactly `tests/test_cvrf_full`.