### PR TITLE
fix: replace pkg_resources by importlib

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -8,7 +8,7 @@ jobs:
     permissions: {}
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -19,7 +19,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         # needed for building lxml wheel für python 3.14 (2026-05-04)
-        apt-get install --assume-yes libxml2-dev libxslt1-dev
+        sudo apt-get install --assume-yes libxml2-dev libxslt1-dev
         pip install pylint
         pip install -r requirements.txt
     - name: Analysing the code with pylint

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -18,6 +18,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        # needed for building lxml wheel für python 3.14 (2026-05-04)
+        apt-get install --assume-yes libxml2-dev libxslt1-dev
         pip install pylint
         pip install -r requirements.txt
     - name: Analysing the code with pylint

--- a/cvrf2csaf/common/utils.py
+++ b/cvrf2csaf/common/utils.py
@@ -7,9 +7,9 @@ import sys
 
 from pathlib import Path
 from datetime import datetime, timezone
+from importlib.resources import files
 
 import yaml
-import pkg_resources
 
 from .common import SectionHandler
 
@@ -47,8 +47,7 @@ def get_config_from_file() -> dict:
     try:
         # pylint: disable=fixme
         # TODO: Workaround for now, config file placement is to be discussed
-        req = pkg_resources.Requirement.parse('cvrf2csaf')
-        path_to_conf = pkg_resources.resource_filename(req, 'cvrf2csaf/config/config.yaml')
+        path_to_conf = str(files('cvrf2csaf').joinpath('config/config.yaml'))
         with open(path_to_conf, 'r', encoding='utf-8') as f:
             config = yaml.safe_load(f)
 

--- a/cvrf2csaf/common/utils.py
+++ b/cvrf2csaf/common/utils.py
@@ -47,9 +47,8 @@ def get_config_from_file() -> dict:
     try:
         # pylint: disable=fixme
         # TODO: Workaround for now, config file placement is to be discussed
-        path_to_conf = str(files('cvrf2csaf').joinpath('config/config.yaml'))
-        with open(path_to_conf, 'r', encoding='utf-8') as f:
-            config = yaml.safe_load(f)
+        config_str = files('cvrf2csaf').joinpath('config/config.yaml').read_text()
+        config = yaml.safe_load(config_str)
 
         for key in ['force', 'fix_insert_current_version_into_revision_history']:
             if key in config.keys():

--- a/cvrf2csaf/cvrf2csaf.py
+++ b/cvrf2csaf/cvrf2csaf.py
@@ -53,12 +53,15 @@ class DocumentHandler:
 
     PACKAGE_NAME = 'cvrf2csaf'
 
-    SCHEMA_FILE = files(PACKAGE_NAME).joinpath('schemata/cvrf/1.2/cvrf.xsd')
+    # an importlib_resources.abc.Traversable which has open()
+    SCHEMA_TRAV = files(PACKAGE_NAME).joinpath('schemata/cvrf/1.2/cvrf.xsd')
+
     CATALOG_FILE = str(files(PACKAGE_NAME).joinpath('schemata/catalog_1_2.xml'))
 
     # Content copied from
     # https://github.com/secvisogram/secvisogram/blob/main/app/lib/app/shared/Core/csaf_2.0_strict.json
-    CSAF_SCHEMA_FILE = files(PACKAGE_NAME).joinpath(
+    # an importlib_resources.abc.Traversable which has open()
+    CSAF_SCHEMA_TRAV = files(PACKAGE_NAME).joinpath(
         'schemata/csaf/2.0/csaf_json_schema_strict.json')
 
     def __init__(self, config, pkg_version):
@@ -158,7 +161,7 @@ class DocumentHandler:
 
     @classmethod
     def _validate_input_against_schema(cls, xml_objectified):
-        with open(cls.SCHEMA_FILE, encoding='utf-8') as f:
+        with open(cls.SCHEMA_TRAV, encoding='utf-8') as f:
             os.environ.update(XML_CATALOG_FILES=cls.CATALOG_FILE)
             schema = etree.XMLSchema(file=f)
 
@@ -201,7 +204,7 @@ class DocumentHandler:
         Validates the CSAF output against the CSAF JSON schema
         return: True if valid, False if invalid
         """
-        with open(self.CSAF_SCHEMA_FILE, encoding='utf-8') as f:
+        with open(self.CSAF_SCHEMA_TRAV, encoding='utf-8') as f:
             csaf_schema_content = json.loads(f.read())
 
         try:

--- a/cvrf2csaf/cvrf2csaf.py
+++ b/cvrf2csaf/cvrf2csaf.py
@@ -56,7 +56,7 @@ class DocumentHandler:
     # an importlib_resources.abc.Traversable which has open()
     SCHEMA_TRAV = files(PACKAGE_NAME).joinpath('schemata/cvrf/1.2/cvrf.xsd')
 
-    CATALOG_FILE = files(PACKAGE_NAME).joinpath('schemata/catalog_1_2.xml')
+    CATALOG_TRAV = files(PACKAGE_NAME).joinpath('schemata/catalog_1_2.xml')
 
     # Content copied from
     # https://github.com/secvisogram/secvisogram/blob/main/app/lib/app/shared/Core/csaf_2.0_strict.json
@@ -163,7 +163,7 @@ class DocumentHandler:
     def _validate_input_against_schema(cls, xml_objectified):
         with open(cls.SCHEMA_TRAV, encoding='utf-8') as f:
             # convert the Traversable to a Path. if package is a zip, this is a tempfile
-            with as_file(cls.CATALOG_FILE) as catalogue_path:
+            with as_file(cls.CATALOG_TRAV) as catalogue_path:
                 os.environ.update(XML_CATALOG_FILES=str(catalogue_path))
                 schema = etree.XMLSchema(file=f)
 

--- a/cvrf2csaf/cvrf2csaf.py
+++ b/cvrf2csaf/cvrf2csaf.py
@@ -8,7 +8,7 @@ import json
 import os
 import re
 from importlib.metadata import version
-from importlib.resources import files
+from importlib.resources import files, as_file
 import turvallisuusneuvonta as mandatory_tests
 
 from lxml import etree
@@ -56,7 +56,7 @@ class DocumentHandler:
     # an importlib_resources.abc.Traversable which has open()
     SCHEMA_TRAV = files(PACKAGE_NAME).joinpath('schemata/cvrf/1.2/cvrf.xsd')
 
-    CATALOG_FILE = str(files(PACKAGE_NAME).joinpath('schemata/catalog_1_2.xml'))
+    CATALOG_FILE = files(PACKAGE_NAME).joinpath('schemata/catalog_1_2.xml')
 
     # Content copied from
     # https://github.com/secvisogram/secvisogram/blob/main/app/lib/app/shared/Core/csaf_2.0_strict.json
@@ -162,8 +162,10 @@ class DocumentHandler:
     @classmethod
     def _validate_input_against_schema(cls, xml_objectified):
         with open(cls.SCHEMA_TRAV, encoding='utf-8') as f:
-            os.environ.update(XML_CATALOG_FILES=cls.CATALOG_FILE)
-            schema = etree.XMLSchema(file=f)
+            # convert the Traversable to a Path. if package is a zip, this is a tempfile
+            with as_file(cls.CATALOG_FILE) as catalogue_path:
+                os.environ.update(XML_CATALOG_FILES=str(catalogue_path))
+                schema = etree.XMLSchema(file=f)
 
         try:
             schema.assertValid(xml_objectified)

--- a/cvrf2csaf/cvrf2csaf.py
+++ b/cvrf2csaf/cvrf2csaf.py
@@ -7,12 +7,13 @@ import argparse
 import json
 import os
 import re
+from importlib.metadata import version
+from importlib.resources import files
 import turvallisuusneuvonta as mandatory_tests
 
 from lxml import etree
 from lxml import objectify
 from jsonschema import Draft202012Validator, ValidationError, SchemaError
-from pkg_resources import get_distribution, Requirement, resource_filename
 
 from .common.utils import get_config_from_file, store_json, critical_exit, create_file_name
 
@@ -52,16 +53,13 @@ class DocumentHandler:
 
     PACKAGE_NAME = 'cvrf2csaf'
 
-    SCHEMA_FILE = resource_filename(Requirement.parse(PACKAGE_NAME),
-                                    f'{PACKAGE_NAME}/schemata/cvrf/1.2/cvrf.xsd')
-    CATALOG_FILE = resource_filename(Requirement.parse(PACKAGE_NAME),
-                                     f'{PACKAGE_NAME}/schemata/catalog_1_2.xml')
+    SCHEMA_FILE = str(files(PACKAGE_NAME).joinpath('schemata/cvrf/1.2/cvrf.xsd'))
+    CATALOG_FILE = str(files(PACKAGE_NAME).joinpath('schemata/catalog_1_2.xml'))
 
     # Content copied from
     # https://github.com/secvisogram/secvisogram/blob/main/app/lib/app/shared/Core/csaf_2.0_strict.json
-    CSAF_SCHEMA_FILE = resource_filename(Requirement.parse(PACKAGE_NAME),
-                                         f'{PACKAGE_NAME}'
-                                         f'/schemata/csaf/2.0/csaf_json_schema_strict.json')
+    CSAF_SCHEMA_FILE = str(files(PACKAGE_NAME).joinpath(
+        'schemata/csaf/2.0/csaf_json_schema_strict.json'))
 
     def __init__(self, config, pkg_version):
         self.document_leaf_elements = DocumentLeafElements(config)
@@ -254,7 +252,7 @@ def main():
     parser = argparse.ArgumentParser(
         description='Converts CVRF 1.2 XML input into CSAF 2.0 JSON output.')
     parser.add_argument('-v', '--version', action='version',
-                        version=str(get_distribution('cvrf2csaf').version))
+                        version=version('cvrf2csaf'))
     parser.add_argument('--input-file', dest='input_file', type=str, required=True,
                         help="CVRF XML input file to parse", metavar='PATH')
     parser.add_argument('--output-dir', dest='output_dir', type=str, default='./', metavar='PATH',
@@ -318,7 +316,7 @@ def main():
         critical_exit(f'Input file not found, check the path: {config.get("input_file")}')
 
     # Get the version of the installed package
-    pkg_version = get_distribution('cvrf2csaf').version
+    pkg_version = version('cvrf2csaf')
 
     # DocumentHandler is iterating over each XML element within convert_file and
     # return CSAF 2.0 JSON

--- a/cvrf2csaf/cvrf2csaf.py
+++ b/cvrf2csaf/cvrf2csaf.py
@@ -53,13 +53,13 @@ class DocumentHandler:
 
     PACKAGE_NAME = 'cvrf2csaf'
 
-    SCHEMA_FILE = str(files(PACKAGE_NAME).joinpath('schemata/cvrf/1.2/cvrf.xsd'))
+    SCHEMA_FILE = files(PACKAGE_NAME).joinpath('schemata/cvrf/1.2/cvrf.xsd')
     CATALOG_FILE = str(files(PACKAGE_NAME).joinpath('schemata/catalog_1_2.xml'))
 
     # Content copied from
     # https://github.com/secvisogram/secvisogram/blob/main/app/lib/app/shared/Core/csaf_2.0_strict.json
-    CSAF_SCHEMA_FILE = str(files(PACKAGE_NAME).joinpath(
-        'schemata/csaf/2.0/csaf_json_schema_strict.json'))
+    CSAF_SCHEMA_FILE = files(PACKAGE_NAME).joinpath(
+        'schemata/csaf/2.0/csaf_json_schema_strict.json')
 
     def __init__(self, config, pkg_version):
         self.document_leaf_elements = DocumentLeafElements(config)


### PR DESCRIPTION
pkg_resources is deprecated and no longer available in current python versions
replace it by calls to stdlib importlib