### PR TITLE
treat turvallisuusneuvonta as warnings only temporarily

### DIFF
--- a/cvrf2csaf/cvrf2csaf.py
+++ b/cvrf2csaf/cvrf2csaf.py
@@ -250,13 +250,13 @@ class DocumentHandler:
                 # https://github.com/csaf-tools/CVRF-CSAF-Converter/issues/138
                 # https://todo.sr.ht/~sthagen/turvallisuusneuvonta/3
                 if not logged_warning:
-                    logging.warning('Due to a bug in the library turvallisuusneuvonta, all '
+                    logging.warning('Due to a defect in the library turvallisuusneuvonta, all '
                                     'reported errors will be treated as warnings instead. See '
                                     'https://github.com/csaf-tools/CVRF-CSAF-Converter/issues/138'
                                     ' for more information.')
                     logged_warning = True
                 # passed = False
-                logging.warning('Mandatory test %s failed.', m_test_str)
+                logging.warning("turvallisuusneuvonta's mandatory test '%s' failed.", m_test_str)
 
         return passed
 

--- a/cvrf2csaf/cvrf2csaf.py
+++ b/cvrf2csaf/cvrf2csaf.py
@@ -238,6 +238,7 @@ class DocumentHandler:
         #  replace the implementation
         # For now we fetch the tests like this to see which failed
         passed = True
+        logged_warning = False
         for m_test_str in mandatory_tests.__all__:
             # Skip translator function since translator value cannot appear on the input
             # Skip is_valid which calls all the tests (but doesn't produce any output)
@@ -245,8 +246,17 @@ class DocumentHandler:
                 continue
             m_test_call = getattr(mandatory_tests, m_test_str)
             if not m_test_call(final_csaf):
-                passed = False
-                logging.error('Mandatory test %s failed.', m_test_str)
+                # turvallisuusneuvonta is broken and any fails are now only warnings
+                # https://github.com/csaf-tools/CVRF-CSAF-Converter/issues/138
+                # https://todo.sr.ht/~sthagen/turvallisuusneuvonta/3
+                if not logged_warning:
+                    logging.warning('Due to a bug in the library turvallisuusneuvonta, all '
+                                    'reported errors will be treated as warnings instead. See '
+                                    'https://github.com/csaf-tools/CVRF-CSAF-Converter/issues/138'
+                                    ' for more information.')
+                    logged_warning = True
+                # passed = False
+                logging.warning('Mandatory test %s failed.', m_test_str)
 
         return passed
 


### PR DESCRIPTION
turvallisuusneuvonta is broken, thus we need to treat any errors from its validation as warnings only
https://todo.sr.ht/~sthagen/turvallisuusneuvonta/3

show a warning about this also in the output if it's happening in this run

fixes https://github.com/csaf-tools/CVRF-CSAF-Converter/issues/138