### PR TITLE
fix: bump lxml to 6.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-lxml>=5.0,<6
+lxml>=6.1.0
 PyYAML>=6.0,<7
 jsonschema>=4.4.0,<5
 turvallisuusneuvonta

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ zip_safe = False
 include_package_data = True
 python_requires = >=3.6
 install_requires =
-    lxml>=5.0,<6
+    lxml>=6.1.0
     PyYAML>=6.0,<7
     jsonschema>=4.4.0,<5
     turvallisuusneuvonta


### PR DESCRIPTION
lxml < 6.1.0 is vulnerable to PYSEC-2026-87

fixes https://github.com/csaf-tools/CVRF-CSAF-Converter/issues/140